### PR TITLE
Fix missing NestJS driver

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@nestjs/common": "9.0.0",
     "@nestjs/core": "9.0.0",
+    "@nestjs/platform-express": "9.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1"
   },


### PR DESCRIPTION
## Summary
- add missing `@nestjs/platform-express` dependency for the API

## Testing
- `yarn build:api` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6846c9dff10483338a301c0ba0265299